### PR TITLE
Feature/issue 18/tests

### DIFF
--- a/__tests__/unit/hooks/useColorTheme.test.ts
+++ b/__tests__/unit/hooks/useColorTheme.test.ts
@@ -39,7 +39,9 @@ describe('useColorTheme', () => {
 
     const { result } = renderHook(() => useColorTheme())
 
-    result.current.initColorTheme()
+    act(() => {
+      result.current.initColorTheme()
+    })
 
     expect(setColorThemeCookie).toHaveBeenCalledWith(colorThemeConfig.light)
     expect(mockDispatch).toHaveBeenCalled();
@@ -51,8 +53,9 @@ describe('useColorTheme', () => {
     mockSelector.mockReturnValue(colorThemeConfig.light)
 
     const { result } = renderHook(() => useColorTheme())
-
-    result.current.initColorTheme()
+    act(() => {
+      result.current.initColorTheme()
+    })
 
     expect(setColorThemeCookie).toHaveBeenCalledWith(colorThemeConfig.dark)
     expect(updateColorTheme).toHaveBeenCalledWith(colorThemeConfig.dark)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "next start",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "test": "jest --verbose",
+    "test": "jest --ci --verbose",
     "test:watch": "jest --watch --verbose"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "next start",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "test": "jest --ci --verbose",
+    "test": "env NODE_ENV=test jest --ci --verbose",
     "test:watch": "jest --watch --verbose"
   },
   "dependencies": {


### PR DESCRIPTION
from "test": "jest --verbose",
to "test": "env NODE_ENV=test jest --ci --verbose",

It worked and all tests passed without 'act(...) is not supported in production builds of React' error